### PR TITLE
feat: saved budget selections with dropdown, persist & delete

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3660,6 +3660,212 @@ body {
   border-top: 1px solid var(--border-color);
 }
 
+/* ── Calculator: Budget Selector ── */
+
+.sc-budget-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.sc-budget-selector {
+  position: relative;
+  flex: 1;
+  max-width: 340px;
+}
+
+.sc-budget-trigger {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 10px 14px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  color: var(--text-primary);
+  font-size: 14px;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.sc-budget-trigger:hover {
+  border-color: var(--accent-primary);
+}
+
+.sc-budget-trigger-text {
+  flex: 1;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sc-budget-chevron {
+  flex-shrink: 0;
+  opacity: 0.5;
+}
+
+.sc-budget-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  box-shadow: 0 12px 40px rgba(0,0,0,0.4);
+  z-index: 100;
+  overflow: hidden;
+  max-height: 340px;
+  overflow-y: auto;
+}
+
+.sc-budget-dropdown-empty {
+  padding: 16px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.sc-budget-dropdown-item {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+
+.sc-budget-dropdown-item--active {
+  background: rgba(139,92,246,0.08);
+}
+
+.sc-budget-dropdown-load {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 14px;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s;
+}
+
+.sc-budget-dropdown-load:hover {
+  background: rgba(255,255,255,0.04);
+}
+
+.sc-budget-dropdown-name {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sc-budget-dropdown-date {
+  font-size: 11px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.sc-budget-dropdown-del {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  margin-right: 6px;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.sc-budget-dropdown-del:hover {
+  background: rgba(239,68,68,0.12);
+  color: #ef4444;
+}
+
+.sc-budget-dropdown-divider {
+  height: 1px;
+  background: var(--border-color);
+}
+
+.sc-budget-save-row {
+  display: flex;
+  gap: 8px;
+  padding: 10px 12px;
+}
+
+.sc-budget-save-input {
+  flex: 1;
+  padding: 7px 10px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 13px;
+  outline: none;
+}
+
+.sc-budget-save-input::placeholder {
+  color: var(--text-muted);
+}
+
+.sc-budget-save-input:focus {
+  border-color: var(--accent-primary);
+}
+
+.sc-budget-save-btn {
+  padding: 7px 14px;
+  background: var(--accent-primary);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: opacity 0.15s;
+}
+
+.sc-budget-save-btn:hover {
+  opacity: 0.85;
+}
+
+.sc-budget-update-btn {
+  padding: 8px 16px;
+  background: rgba(34,211,238,0.1);
+  color: #22d3ee;
+  border: 1px solid rgba(34,211,238,0.25);
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+
+.sc-budget-update-btn:hover {
+  background: rgba(34,211,238,0.18);
+}
+
+@media (max-width: 640px) {
+  .sc-budget-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .sc-budget-selector {
+    max-width: none;
+  }
+}
+
 /* ── Calculator: Export Section ── */
 
 .sc-export-section {

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -606,6 +606,11 @@ const CATEGORY_META: Record<ReportCategory, { label: string; icon: string; empty
     icon: '📈',
     emptyText: 'No portfolio reports yet. Select scenarios below to generate.',
   },
+  'net-worth': {
+    label: 'Net Worth',
+    icon: '📊',
+    emptyText: 'No net worth reports yet. Export one from the Net Worth page.',
+  },
 };
 
 // ── Download helpers ──

--- a/src/services/userDataService.ts
+++ b/src/services/userDataService.ts
@@ -20,7 +20,7 @@ import {
   type DocumentData,
 } from 'firebase/firestore';
 import { db } from '../config/firebase';
-import type { SavedScenario } from '../types';
+import type { SavedScenario, SavedBudget } from '../types';
 import type { NetWorthData } from '../pages/NetWorthPage';
 
 // ── Helpers ──
@@ -106,4 +106,22 @@ export async function loadUserSettings(uid: string): Promise<UserSettings | null
 export async function saveUserSettings(uid: string, settings: UserSettings): Promise<void> {
   if (!db) return;
   await setDoc(userDoc(uid, 'settings', 'prefs'), settings, { merge: true });
+}
+
+// ── Saved Budgets ──
+
+export async function loadBudgets(uid: string): Promise<SavedBudget[]> {
+  if (!db) return [];
+  const snap = await getDocs(userCol(uid, 'budgets'));
+  return snap.docs.map((d) => ({ id: d.id, ...d.data() }) as SavedBudget);
+}
+
+export async function saveBudget(uid: string, budget: SavedBudget): Promise<void> {
+  if (!db) return;
+  await setDoc(userDoc(uid, 'budgets', budget.id), budget as unknown as DocumentData);
+}
+
+export async function removeBudget(uid: string, budgetId: string): Promise<void> {
+  if (!db) return;
+  await deleteDoc(userDoc(uid, 'budgets', budgetId));
 }

--- a/src/state/CalculatorContext.tsx
+++ b/src/state/CalculatorContext.tsx
@@ -22,7 +22,8 @@ type Action =
   | { type: 'SET_INCOME_FREQUENCY'; payload: IncomeFrequency }
   | { type: 'ADD_EXPENSE'; payload: { name: string; amount: number; icon?: string } }
   | { type: 'REMOVE_EXPENSE'; payload: string }
-  | { type: 'UPDATE_EXPENSE'; payload: { id: string; name?: string; amount?: number; icon?: string } };
+  | { type: 'UPDATE_EXPENSE'; payload: { id: string; name?: string; amount?: number; icon?: string } }
+  | { type: 'LOAD_STATE'; payload: CalculatorState };
 
 function reducer(state: CalculatorState, action: Action): CalculatorState {
   switch (action.type) {
@@ -55,6 +56,8 @@ function reducer(state: CalculatorState, action: Action): CalculatorState {
           e.id === action.payload.id ? { ...e, ...action.payload } : e,
         ),
       };
+    case 'LOAD_STATE':
+      return action.payload;
     default:
       return state;
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,8 +40,19 @@ export interface NavItem {
   isSettings?: boolean;
 }
 
+// ── Saved Budgets ──
+export interface SavedBudget {
+  id: string;
+  name: string;
+  income: number;
+  incomeFrequency: IncomeFrequency;
+  expenses: Expense[];
+  createdAt: string;
+  updatedAt: string;
+}
+
 // ── Saved Reports ──
-export type ReportCategory = 'take-home-pay' | 'savings-calculator' | 'portfolio-simulation';
+export type ReportCategory = 'take-home-pay' | 'savings-calculator' | 'portfolio-simulation' | 'net-worth';
 
 export interface SavedReport {
   id: string;


### PR DESCRIPTION
- Add SavedBudget type with income, expenses, timestamps
- Add LOAD_STATE action to CalculatorContext for restoring budgets
- Add Firestore persistence (loadBudgets, saveBudget, removeBudget)
- Budget dropdown selector above calculator with save/load/delete
- Sync budgets from Firestore on login
- Update active budget in-place
- Add net-worth category to ReportCategory for future use
- Full CSS for budget selector with responsive mobile layout