### PR TITLE
UI: Fix Monte Carlo chart & mobile flip behavior; add collapsible cas…

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3069,6 +3069,47 @@ body {
   margin-bottom: 16px;
 }
 
+.ps-cashflow-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0;
+  margin-bottom: 12px;
+  background: transparent;
+  border: none;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.ps-cashflow-toggle-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.ps-cashflow-arrow {
+  font-size: 12px;
+  color: var(--text-muted);
+  transition: transform 0.25s;
+}
+
+.ps-cashflow-arrow--open {
+  transform: rotate(180deg);
+}
+
+.ps-cashflow-body {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.35s ease;
+}
+
+.ps-cashflow-body--open {
+  max-height: 1200px;
+}
+
 .ps-filter-btn {
   padding: 5px 12px;
   border-radius: 20px;
@@ -3505,6 +3546,7 @@ body {
   width: 100%;
   min-height: 460px;
   perspective: 1200px;
+  overflow: hidden;
 }
 
 .ps-flip-container > .ps-flip-face {
@@ -7345,6 +7387,17 @@ a.header-logo {
 
 /* ── Portfolio Simulator mobile layout ── */
 @media (max-width: 768px) {
+  .ps-page,
+  .ps-grid,
+  .ps-left,
+  .ps-right,
+  .ps-card,
+  .ps-flip-container,
+  .ps-flip-container > .ps-flip-face {
+    min-width: 0;
+    max-width: 100%;
+  }
+
   /* Cards: tighter padding */
   .ps-card {
     padding: 16px 12px;
@@ -7406,9 +7459,36 @@ a.header-logo {
     font-size: 18px;
   }
 
-  /* Flip container / Monte Carlo chart: reduce heights */
+  /* Flip container / Monte Carlo chart: avoid clipping by using flow layout on mobile */
   .ps-flip-container {
-    min-height: 340px;
+    min-height: 0;
+    perspective: none;
+    overflow: hidden;
+  }
+
+  .ps-flip-container > .ps-flip-face {
+    position: static;
+    height: auto;
+    transform: none;
+    transition: none;
+    backface-visibility: visible;
+    -webkit-backface-visibility: visible;
+  }
+
+  .ps-flip-face--back {
+    display: none;
+  }
+
+  .ps-flip-container--flipped .ps-flip-face--front {
+    display: none;
+  }
+
+  .ps-flip-container--flipped .ps-flip-face--back {
+    display: block;
+  }
+
+  .ps-flip-face--front .ps-chart-container {
+    overflow: visible;
   }
 
   .ps-chart-container {
@@ -7432,6 +7512,20 @@ a.header-logo {
 
   .ps-result-value {
     font-size: 16px;
+    text-align: right;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .ps-result-item > * {
+    min-width: 0;
+  }
+
+  .ps-scenario-amount,
+  .ps-scenario-dates,
+  .ps-scenario-growth {
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 
   /* Scenario manager card */

--- a/src/components/portfolio/MonteCarloChart.tsx
+++ b/src/components/portfolio/MonteCarloChart.tsx
@@ -208,6 +208,13 @@ export function MonteCarloChart({ data, result, currencyCode }: MonteCarloChartP
   const [flipped, setFlipped] = useState(false);
   const [hoveredLabel, setHoveredLabel] = useState('');
 
+  const yAxisDomain = useMemo<[number, number]>(() => {
+    if (!data.length) return [0, 0];
+    const minP10 = Math.min(...data.map((d) => d.p10));
+    const maxP75 = Math.max(...data.map((d) => d.p75));
+    return [Math.min(0, minP10), maxP75];
+  }, [data]);
+
   // Pre-compute stacked band data for correct layering
   const chartData = useMemo(() => {
     return data.map((d) => ({
@@ -250,7 +257,7 @@ export function MonteCarloChart({ data, result, currencyCode }: MonteCarloChartP
           <ResponsiveContainer width="100%" height={380}>
             <AreaChart
               data={chartData}
-              margin={{ top: 10, right: 10, left: 10, bottom: 0 }}
+              margin={{ top: 8, right: 2, left: -8, bottom: 18 }}
               onMouseMove={handleMouseMove}
             >
               <defs>
@@ -271,6 +278,8 @@ export function MonteCarloChart({ data, result, currencyCode }: MonteCarloChartP
                 tick={{ fill: 'var(--text-muted)', fontSize: 11 }}
                 axisLine={{ stroke: 'var(--border-color)' }}
                 tickLine={false}
+                tickMargin={8}
+                height={30}
                 interval="preserveStartEnd"
               />
 
@@ -278,6 +287,9 @@ export function MonteCarloChart({ data, result, currencyCode }: MonteCarloChartP
                 tick={{ fill: 'var(--text-muted)', fontSize: 11 }}
                 axisLine={false}
                 tickLine={false}
+                tickMargin={4}
+                width={34}
+                domain={yAxisDomain}
                 tickFormatter={(v) => {
                   if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
                   if (v >= 1_000) return `${(v / 1_000).toFixed(0)}K`;

--- a/src/pages/PortfolioSimulatorPage.tsx
+++ b/src/pages/PortfolioSimulatorPage.tsx
@@ -520,6 +520,7 @@ export function PortfolioSimulatorPage() {
   const pendingSwitchRef = useRef<string | null>(null);
   const [pendingEditId, setPendingEditId] = useState<string | null>(null);
   const [horizonMode, setHorizonMode] = usePersistedState<'date' | 'years'>('vf-ps-horizon-mode', 'years');
+  const [cashFlowsOpen, setCashFlowsOpen] = useState(false);
   const [tableOpen, setTableOpen] = useState(false);
   const [showSaveAs, setShowSaveAs] = useState(false);
   const { gate, showLogin: showLoginModal, onLoginSuccess, onLoginClose } = useAuthGate();
@@ -1024,41 +1025,52 @@ export function PortfolioSimulatorPage() {
           {/* Cash Flow List */}
           {cashFlows.length > 0 && (
             <div className="ps-card">
-              <h2 className="ps-card-title">
-                Cash Flows
-                <span className="ps-scenario-count">{cashFlows.length}</span>
-              </h2>
+              <button
+                className="ps-cashflow-toggle"
+                onClick={() => setCashFlowsOpen((v) => !v)}
+                aria-expanded={cashFlowsOpen}
+              >
+                <span className="ps-cashflow-toggle-title">
+                  Cash Flows
+                  <span className="ps-scenario-count">{cashFlows.length}</span>
+                </span>
+                <span className={`ps-cashflow-arrow ${cashFlowsOpen ? 'ps-cashflow-arrow--open' : ''}`}>
+                  ▼
+                </span>
+              </button>
 
-              {/* Filter pills */}
-              <div className="ps-filter">
-                {(['all', 'deposits', 'withdrawals'] as const).map((f) => (
-                  <button
-                    key={f}
-                    className={`ps-filter-btn ${cashFlowFilter === f ? 'ps-filter-btn--active' : ''}`}
-                    onClick={() => setCashFlowFilter(f)}
-                  >
-                    {f === 'all' ? 'All' : f === 'deposits' ? '📥 Deposits' : '📤 Withdrawals'}
-                  </button>
-                ))}
-              </div>
-
-              <div className="ps-scenario-list">
-                {cashFlows
-                  .filter((cf) => {
-                    if (cashFlowFilter === 'all') return true;
-                    if (cashFlowFilter === 'deposits') return cf.type !== 'recurring-withdrawal';
-                    return cf.type === 'recurring-withdrawal';
-                  })
-                  .map((cf) => (
-                    <CashFlowCard
-                      key={cf.id}
-                      cashFlow={cf}
-                      currencyCode={currency.code}
-                      onEdit={handleEditCashFlow}
-                      onDelete={handleDeleteCashFlow}
-                      onToggle={handleToggleCashFlow}
-                    />
+              <div className={`ps-cashflow-body ${cashFlowsOpen ? 'ps-cashflow-body--open' : ''}`}>
+                {/* Filter pills */}
+                <div className="ps-filter">
+                  {(['all', 'deposits', 'withdrawals'] as const).map((f) => (
+                    <button
+                      key={f}
+                      className={`ps-filter-btn ${cashFlowFilter === f ? 'ps-filter-btn--active' : ''}`}
+                      onClick={() => setCashFlowFilter(f)}
+                    >
+                      {f === 'all' ? 'All' : f === 'deposits' ? '📥 Deposits' : '📤 Withdrawals'}
+                    </button>
                   ))}
+                </div>
+
+                <div className="ps-scenario-list">
+                  {cashFlows
+                    .filter((cf) => {
+                      if (cashFlowFilter === 'all') return true;
+                      if (cashFlowFilter === 'deposits') return cf.type !== 'recurring-withdrawal';
+                      return cf.type === 'recurring-withdrawal';
+                    })
+                    .map((cf) => (
+                      <CashFlowCard
+                        key={cf.id}
+                        cashFlow={cf}
+                        currencyCode={currency.code}
+                        onEdit={handleEditCashFlow}
+                        onDelete={handleDeleteCashFlow}
+                        onToggle={handleToggleCashFlow}
+                      />
+                    ))}
+                </div>
               </div>
             </div>
           )}


### PR DESCRIPTION
…h flows

- Monte CarloChart: reduce left gutter, tighten margins, increase bottom margin and XAxis height so labels are visible; set Y-axis domain to lowest p10 / highest p75 to focus on 25th–75th envelope.
- Mobile flip card: switch to stacked faces on small screens so distribution back-face no longer clips; keep desktop 3D flip behaviour.
- Prevent front chart from spilling out of card; adjust container overflow rules.
- Cash flows: add collapsible header with persistent count; default collapsed on load.
- Misc: CSS tweaks to keep charts contained on mobile and improve chart spacing.